### PR TITLE
Check Release/Stemcell versions in-line with HTTP requests

### DIFF
--- a/api_release.go
+++ b/api_release.go
@@ -114,8 +114,8 @@ func (api ReleaseAPI) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		vers := extract(r, `/v1/release/[^/]+/v/([^/]+)`)
 		log.Debugf("checking for version '%s' of release '%s'", vers, name)
 
-		go CheckReleaseVersion(api.db, name, vers)
-		respond(w, nil, 200, "task started in background")
+		err := CheckReleaseVersion(api.db, name, vers)
+		respond(w, err, 200, "task started in background")
 		return
 
 	case match(r, `DELETE /v1/release/[^/]+/v/[^/]+`):

--- a/api_stemcell.go
+++ b/api_stemcell.go
@@ -114,8 +114,8 @@ func (api StemcellAPI) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		vers := extract(r, `/v1/stemcell/[^/]+/v/([^/]+)`)
 		log.Debugf("checking for version '%s' of stemcell '%s'", vers, name)
 
-		go CheckStemcellVersion(api.db, name, vers)
-		respond(w, nil, 200, "task started in background")
+		err := CheckStemcellVersion(api.db, name, vers)
+		respond(w, err, 200, "task started in background")
 		return
 
 	case match(r, `DELETE /v1/stemcell/[^/]+/v/[^/]+`):


### PR DESCRIPTION
This way, end users get better feedback when they give invalid behavior.
All the "short" verification checks can be done synchronously, and the
"long" work tasks in a goroutine.

Fixes #6 

cc @geofffranks 
