### PR TITLE
Support disabled releases

### DIFF
--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ func main() {
 	log.Infof("genesis-index starting up")
 
 	var d *db.DB
-	if dsn, err := ParseVcap(os.Getenv("VCAP_SERVICES"), "postgres", "uri"); err == nil {
+	if dsn, err := ParseVcap(os.Getenv("VCAP_SERVICES"), "postgresql", "uri"); err == nil {
 		d, err = Database("postgres", fmt.Sprintf("%s?sslmode=disable", dsn))
 		if err != nil {
 			log.Infof("Unable to connect to database: %s", err)
@@ -37,6 +37,9 @@ func main() {
 			return
 		}
 	} else {
+		if err != nil {
+			log.Errorf("DB Connection error: %s", err)
+		}
 		log.Errorf("Unable to determine DSN for backing database")
 		log.Errorf("No service tagged 'postgres' is bound (per the VCAP_SERVICES environment variable)")
 		log.Errorf("and SQLITE_DB environment variable is not set.")

--- a/manifest-test.yml
+++ b/manifest-test.yml
@@ -1,0 +1,10 @@
+---
+applications:
+  - name:      genesis-index-test
+    host:      genesis-test
+    domain:    starkandwayne.com
+    memory:    64M
+    command:   genesis-index
+    buildpack: go_buildpack
+    services:
+    - genesis-index-test-db

--- a/pipeline/pipeline.yml
+++ b/pipeline/pipeline.yml
@@ -12,7 +12,6 @@ groups:
   - bosh-vsphere-cpi
   - bosh-warden-cpi
   - bosh
-  - cf-haproxy
   - cf-mysql
   - cf-rabbitmq
   - cf-redis
@@ -380,33 +379,6 @@ jobs:
         GENESIS_CREDS: REDACTED:REDACTED
         GENESIS_INDEX: https://genesis.starkandwayne.com
         SUBJECT: bosh
-      platform: linux
-      run:
-        args: []
-        path: ./run/check-version
-    task: update-index
-  public: true
-  serial: false
-- name: cf-haproxy
-  plan:
-  - get: cf-haproxy
-    trigger: true
-  - get: version-check-script
-  - config:
-      image_resource:
-        source:
-          repository: starkandwayne/concourse
-        type: docker-image
-      inputs:
-      - name: cf-haproxy
-        path: release
-      - name: version-check-script
-        path: run
-      params:
-        CHECK_TYPE: release
-        GENESIS_CREDS: REDACTED:REDACTED
-        GENESIS_INDEX: https://genesis.starkandwayne.com
-        SUBJECT: cf-haproxy
       platform: linux
       run:
         args: []
@@ -1761,10 +1733,6 @@ resources:
 - name: bosh
   source:
     repository: cloudfoundry/bosh
-  type: bosh-io-release
-- name: cf-haproxy
-  source:
-    repository: cloudfoundry-community/cf-haproxy-boshrelease
   type: bosh-io-release
 - name: cf-mysql
   source:

--- a/pipeline/repipe
+++ b/pipeline/repipe
@@ -11,6 +11,14 @@ pushd $PIPELINE >/dev/null
 	mkdir releases stemcells
 
 	for release in $(curl -Lsk ${GENESIS_INDEX}/v1/release | jq -r .[]); do
+		disabled=$(curl -Lsk ${GENESIS_INDEX}/v1/release/${release}/metadata | jq -r .disabled)
+		if [[ ${disabled} == "true" ]]; then
+			echo skipping $release
+			# FIXME this isn't enough?
+			continue
+		fi
+		echo processing $release
+
 		url=$(curl -Lsk ${GENESIS_INDEX}/v1/release/${release}/metadata | jq -r .url)
 		if echo $url | egrep -q "^https?://bosh.io/"; then
 			shopt -s extglob

--- a/release.go
+++ b/release.go
@@ -8,10 +8,11 @@ import (
 )
 
 type Release struct {
-	Name    string `json:"name"`
-	Version string `json:"version,omitempty"`
-	SHA1    string `json:"sha1,omitempty"`
-	URL     string `json:"url,omitempty"`
+	Name     string `json:"name"`
+	Version  string `json:"version,omitempty"`
+	SHA1     string `json:"sha1,omitempty"`
+	URL      string `json:"url,omitempty"`
+	Disabled bool   `json:"disabled"`
 }
 
 func CreateRelease(d *db.DB, name, url string) error {
@@ -40,7 +41,7 @@ func FindAllReleases(d *db.DB) ([]string, error) {
 func FindRelease(d *db.DB, name string) (Release, error) {
 	var o Release
 
-	r, err := d.Query(`SELECT name, url FROM releases WHERE name = $1`, name)
+	r, err := d.Query(`SELECT name, url, disabled FROM releases WHERE name = $1`, name)
 	if err != nil {
 		return o, err
 	}
@@ -48,7 +49,7 @@ func FindRelease(d *db.DB, name string) (Release, error) {
 	if !r.Next() {
 		return o, fmt.Errorf("release '%s' not found", name)
 	}
-	if err = r.Scan(&o.Name, &o.URL); err != nil {
+	if err = r.Scan(&o.Name, &o.URL, &o.Disabled); err != nil {
 		return o, err
 	}
 	if r.Next() {
@@ -257,5 +258,5 @@ func CheckReleaseVersion(d *db.DB, name, version string) error {
 		}
 	}()
 
-	return nil;
+	return nil
 }

--- a/schema.go
+++ b/schema.go
@@ -77,6 +77,18 @@ func Database(driver, dsn string) (*db.DB, error) {
 		/* this migration is now done every time, since its idempotent */
 		return nil
 	}) // }}}
+	s.Version(3, func(d *db.DB) error { // {{{
+		err = d.Exec(`
+  ALTER TABLE releases
+    ADD COLUMN disabled BOOL DEFAULT false
+`)
+
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}) // }}}
 
 	err = s.Migrate(d, db.Latest)
 	if err != nil {


### PR DESCRIPTION
By setting the disabled field in the genesis-index database
to 'true', you indicate that the releases should no longer be
picked up by the Concourse pipeline to watch for new releases.

Old versions still remain in the index, but the release will
no longer be watched for new versions.